### PR TITLE
🎉 Update CI workflow and code for enhanced build and plugin managemen…

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         repository: ${{ github.actor }}/binexport
         path: binexport
-        ref: fork
+        ref: test
 
     - name: Install ninja-build tool
       uses: turtlesec-no/get-ninja@1.1.0


### PR DESCRIPTION
…t! 🔧🚀

- bump upload-artifact to @v4
- **Modified GitHub Actions Workflow (`.github/workflows/cmake.yml`):**
  - Added `workflow_dispatch` to trigger builds manually. 📅🤖
  - Updated macOS version in matrix from `macos-12` to `macos-14`. 🖥️🔄
  - Adjusted Ninja installation to install via Homebrew on macOS 14 instead of globally. 🍺📥
  - Changed the SDK version for Windows builds to `10.0.22621.0` for better compatibility. 🏆
  - Updated IDA SDK version from `teams82` to `ida91`, reflecting the latest changes. 🚀📦
  - Changed artifact path upload to include all bindiff-related paths with a wildcard. 📦✨

- **Updated CMakeLists (`ida/CMakeLists.txt`):**
  - Updated comments and expectations regarding plugin naming to simplify process with IDA 9's unique support for 64-bit. 📑🔍
  - Ensured the addition of plugins is seamless with no confusion on naming conventions. 🎉👨‍💻

- **Refactored Java Code (`ExternalAppUtils.java`):**
  - Simplified the logic in `getIdaExe` method to always point to `IDA_EXECUTABLE`, making it cleaner and easier to maintain! 🧹🖥️

- **Adjusted Helper Functions in (`IdaHelpers.java`):**
  - Removed redundant `IDA32_EXECUTABLE` and `IDA64_EXECUTABLE` variables, now using a unified `IDA_EXECUTABLE`. 🌐🛠️

- **Tweaked Config Setup Logic (`config_setup.cc`):**
  - Removed unnecessary references to `bindiff_ida64` in plugin naming for clarity and conformity with new IDA requirements. 🔧✨

These changes were implemented to improve build consistency across platforms, update SDK versions for compatibility, and streamline our workflow ➡️ leading to happier developers and a smoother CI process! 😄🍀…t! 🔧🚀

- bump upload-artifact to @v4
- **Modified GitHub Actions Workflow (`.github/workflows/cmake.yml`):**
  - Added `workflow_dispatch` to trigger builds manually. 📅🤖
  - Updated macOS version in matrix from `macos-12` to `macos-14`. 🖥️🔄
  - Adjusted Ninja installation to install via Homebrew on macOS 14 instead of globally. 🍺📥
  - Changed the SDK version for Windows builds to `10.0.22621.0` for better compatibility. 🏆
  - Updated IDA SDK version from `teams82` to `ida91`, reflecting the latest changes. 🚀📦
  - Changed artifact path upload to include all bindiff-related paths with a wildcard. 📦✨

- **Updated CMakeLists (`ida/CMakeLists.txt`):**
  - Updated comments and expectations regarding plugin naming to simplify process with IDA 9's unique support for 64-bit. 📑🔍
  - Ensured the addition of plugins is seamless with no confusion on naming conventions. 🎉👨‍💻

- **Refactored Java Code (`ExternalAppUtils.java`):**
  - Simplified the logic in `getIdaExe` method to always point to `IDA_EXECUTABLE`, making it cleaner and easier to maintain! 🧹🖥️

- **Adjusted Helper Functions in (`IdaHelpers.java`):**
  - Removed redundant `IDA32_EXECUTABLE` and `IDA64_EXECUTABLE` variables, now using a unified `IDA_EXECUTABLE`. 🌐🛠️

- **Tweaked Config Setup Logic (`config_setup.cc`):**
  - Removed unnecessary references to `bindiff_ida64` in plugin naming for clarity and conformity with new IDA requirements. 🔧✨

These changes were implemented to improve build consistency across platforms, update SDK versions for compatibility, and streamline our workflow ➡️ leading to happier developers and a smoother CI process! 😄🍀